### PR TITLE
Initial implementation of inject.dart support (BindingAnnotation)

### DIFF
--- a/lib/dado.dart
+++ b/lib/dado.dart
@@ -59,6 +59,7 @@ library dado;
 
 import 'dart:async';
 import 'dart:mirrors';
+import 'package:inject/inject.dart';
 import 'src/mirror_utils.dart';
 
 typedef Object _Provider(Injector injector);
@@ -66,6 +67,10 @@ typedef Object _Provider(Injector injector);
 Symbol _typeName(Type type) => reflectClass(type).qualifiedName;
 
 Key _makeKey(dynamic k) => (k is Key) ? k : new Key.forType(k);
+
+class Named extends BindingAnnotation {
+  const Named (String value) : super (value);
+}
 
 /**
  * Keys are used to resolve instances in an [Injector], they are used to
@@ -220,11 +225,15 @@ class Injector {
       return null;
     }
     if (metadata.isNotEmpty) {
-      // TODO(justin): what do we do when a declaration has multiple
-      // annotations? What does Guice do? We should probably only allow one
-      // binding annotation per declaration, which means we need a way to
-      // identify binding annotations.
-      return metadata.first.reflectee;
+      Iterable<InstanceMirror> bindingAnnotations = 
+        metadata.where((annotation) => annotation.reflectee is BindingAnnotation);
+      
+      if (bindingAnnotations.isEmpty)
+        return null;
+      else if (bindingAnnotations.length == 1)
+        return bindingAnnotations.first.reflectee;
+      else
+        throw new ArgumentError('Binding has more than one BindingAnnotation');
     }
     return null;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ description: An experimental dependency injection container for Dart
 homepage: http://dart-lang.github.io/dado/
 documentation: http://dart-lang.github.io/dado/docs/dado.html
 dependencies:
+  inject: any
   logging: any
 dev_dependencies:
   unittest: any

--- a/test/dado_test.dart
+++ b/test/dado_test.dart
@@ -56,9 +56,6 @@ class Provided {
   Provided(int this.i, Foo foo);
 }
 
-const A = 'a';
-const B = 'b';
-
 abstract class Module1 extends Module {
 
   // an instance of a type, similar to bind().toInstance() in Guice
@@ -66,12 +63,12 @@ abstract class Module1 extends Module {
 
   // an annotated instance which can be requested independently of an
   // unannotated binding or a binding with a different annotation
-  @B String another_string = "b";
+  @Named('b') String another_string = "b";
 
   // a singleton, similar to bind().to().in(Singleton.class) in Guice
   Foo get foo;
 
-  @B Foo get fooB;
+  @Named('b') Foo get fooB;
 
   // a factory binding, similar to bind().to() in Guice
   Bar newBar();
@@ -118,7 +115,7 @@ main() {
     });
 
     test('should return the value of an annotated instance field', () {
-      expect(injector.getInstanceOf(String, annotatedWith: B), 'b');
+      expect(injector.getInstanceOf(String, annotatedWith: const Named('b')), 'b');
     });
 
     test('should return a singleton of the return type of a getter', () {
@@ -193,7 +190,7 @@ main() {
     setUp((){
       injector = new Injector([Module1], name: 'parent');
       childInjector = new Injector([Module3],
-          newInstances: [Baz, new Key.forType(Foo, annotatedWith: B)],
+          newInstances: [Baz, new Key.forType(Foo, annotatedWith: const Named('b'))],
           parent: injector,
           name: 'child');
     });
@@ -227,8 +224,8 @@ main() {
       var baz2 = childInjector.getInstanceOf(Baz);
       expect(baz1, isNot(same(baz2)));
 
-      var fooB1 = injector.getInstanceOf(Foo, annotatedWith: B);
-      var fooB2 = childInjector.getInstanceOf(Foo, annotatedWith: B);
+      var fooB1 = injector.getInstanceOf(Foo, annotatedWith: const Named('b'));
+      var fooB2 = childInjector.getInstanceOf(Foo, annotatedWith: const Named('b'));
       expect(fooB1, isNot(same(fooB2)));
     });
 


### PR DESCRIPTION
This patch makes dado use inject's BindingAnnotation to recognize metadata that define bindings (now only BindingAnnotation metadata is used by dado as opposed to any metadata). Named class has been included as an easy to use BindingAnnotation.

Probably you guys have already done this internally, but in case you didn't here it is. 

Actually, I made this to ask you if I may contribute to this project. May I proceed with the implementation of @inject?
