### PR TITLE
Constructor selection based on @inject annotation, reformulated binding registration and circular dependency verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,15 +109,15 @@ class Bar {
 }
 
 class Baz {
-	String serverAddress;
-	
-	Baz();
-	
-	// In classes that have multiple constructors, the desired constructor can
-	// be selected using the @inject annotation. Otherwise, Dado will look for
-	// a no-args constructor.
-	@inject
-	Baz.injectable(String this.serverAddress);
+  String serverAddress;
+  
+  Baz();
+  
+  // In classes that have multiple constructors, the desired constructor can
+  // be selected using the @inject annotation. Otherwise, Dado will look for
+  // a no-args constructor.
+  @inject
+  Baz.injectable(String this.serverAddress);
 }
 
 main() {

--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ class Bar {
   Bar(Foo foo);
 }
 
+class Baz {
+	String serverAddress;
+	
+	Baz();
+	
+	// In classes that have multiple constructors, the desired constructor can
+	// be selected using the @inject annotation. Otherwise, Dado will look for
+	// a no-args constructor.
+	@inject
+	Baz.injectable(String this.serverAddress);
+}
+
 main() {
   var injector = new Injector([MyModule]);
   Bar bar = injector.getInstance(Bar);
@@ -122,8 +134,6 @@ production yet.
 Known Issues and Limitations
 ----------------------------
 
- * Injectable classes must either have a default constructor or a single
-   constructor.
  * There can only be one binding per type, because parameter annotations cannot
    be access via mirrors yet. When issue 11418 is fixed, Dado will respect
    annotations of parameters.
@@ -137,7 +147,7 @@ Known Issues and Limitations
 Star Fishing
 ------------
 
-These are open issues that are blocking certain features od Dado:
+These are open issues that are blocking certain features of Dado:
 
  * http://dartbug.com/5897 Look up classes by name
  * http://dartbug.com/9395 Get qualified name from Type

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ class MyModule extends Module {
 }
 
 class Bar {
-  // A default method is automatically injected with dependencies
+  // When there is only one constructor, it is automatically injected with
+  // dependencies
   Bar(Foo foo);
 }
 

--- a/lib/dado.dart
+++ b/lib/dado.dart
@@ -59,7 +59,6 @@ library dado;
 
 import 'dart:mirrors';
 import 'package:inject/inject.dart';
-import 'package:meta/meta.dart';
 import 'src/mirror_utils.dart';
 
 part 'src/binding.dart';
@@ -246,7 +245,7 @@ class Injector {
     var classMirror = reflectClass(moduleType);
     var moduleMirror = classMirror.newInstance(const Symbol(''), [], null);
 
-    classMirror.members.values.forEach((member) {
+    classMirror.declarations.values.forEach((member) {
       if (member is VariableMirror) {
         // Variables define "to instance" bindings
         var instance = moduleMirror.getField(member.simpleName).reflectee;
@@ -332,7 +331,7 @@ class Injector {
   }
   
   MethodMirror _selectConstructor(ClassMirror m) {
-    Iterable<MethodMirror> constructors = m.constructors.values;
+    Iterable<MethodMirror> constructors = getConstructorsMirrors(m);
     // Choose contructor using @inject
     MethodMirror ctor = constructors.firstWhere(
       (c) => c.metadata.any(
@@ -352,7 +351,7 @@ class Injector {
     }
         
     if (ctor == null) {
-      throw new ArgumentError("${m.qualifiedName} musthave only "
+      throw new ArgumentError("${m.qualifiedName} must have only "
         "one constructor, a constructor annotated with @inject or no-args "
         "constructor");
     }

--- a/lib/dado.dart
+++ b/lib/dado.dart
@@ -243,7 +243,6 @@ class Injector {
     var moduleMirrors = modules.map((moduleType) => reflectClass(moduleType));
     
     moduleMirrors.forEach(_registerBindings);
-    //moduleMirrors.forEach(_analyzeObjectGraph);
   }
 
   /**
@@ -385,57 +384,6 @@ class Injector {
       }
     });
   }
-  
-//  void _analyzeObjectGraph (ClassMirror classMirror) {
-//    classMirror.members.values.forEach((member) {
-//      
-//      // There is no way that "to instance" bindings could have circular
-//      // dependencies, so we only analyze the others bindings
-//      if (member is MethodMirror) {
-//        if (member.isAbstract) {
-//          _verifyCycle(member.returnType, _getAnnotation(member));
-//        } else if (!member.isGetter) {
-//          member.parameters.forEach((p) {
-//            var pAnnotation = _getAnnotation(p);
-//            var pKey = new Key(p.type.qualifiedName, 
-//                annotatedWith: pAnnotation);
-//            
-//            var instance = _singletons[pKey];
-//            if (instance != null)
-//              return;
-//            
-//            _verifyCycle(p.type, pAnnotation, 
-//                dependencyStack: [member.returnType.qualifiedName]);
-//          });
-//        }
-//      }
-//    });
-//  }
-//  
-//  void _verifyCycle (TypeMirror m, annotation, 
-//                     {List<Symbol> dependencyStack}) {
-//    if (dependencyStack == null)
-//      dependencyStack = [m.qualifiedName];
-//    
-//    MethodMirror ctor = _selectConstructor(m);
-//    ctor.parameters.forEach((p) {
-//      var pAnnotation = _getAnnotation(p);
-//      var pKey = new Key(p.type.qualifiedName, 
-//          annotatedWith: pAnnotation);
-//      
-//      var instance = _singletons[pKey];
-//      if (instance != null)
-//        return;
-//      
-//      if (dependencyStack.contains(p.type.qualifiedName))
-//        throw new ArgumentError("Circular dependency found on type "
-//            "${p.type.qualifiedName}.");
-//      
-//      dependencyStack.add(p.type.qualifiedName);
-//      _verifyCycle(p.type, pAnnotation, dependencyStack: dependencyStack);
-//      dependencyStack.removeLast();
-//    });
-//  }
   
   MethodMirror _selectConstructor (ClassMirror m) {
     Iterable<MethodMirror> constructors = m.constructors.values;

--- a/lib/dado.dart
+++ b/lib/dado.dart
@@ -79,13 +79,13 @@ Key _makeKey(dynamic k) => (k is Key) ? k : new Key.forType(k);
  */
 class Key {
   final Symbol name;
-  final annotation;
+  final Object annotation;
 
-  Key(this.name, {annotatedWith}) : annotation = annotatedWith {
+  Key(this.name, {Object annotatedWith}) : annotation = annotatedWith {
     if (name == null) throw new ArgumentError("name must not be null");
   }
 
-  factory Key.forType(Type type, {annotatedWith}) =>
+  factory Key.forType(Type type, {Object annotatedWith}) =>
       new Key(_typeName(type), annotatedWith: annotatedWith);
 
   bool operator ==(o) => o is Key && o.name == name
@@ -172,7 +172,7 @@ class Injector {
    * Returns an instance of [type]. If [annotatedWith] is provided, returns an
    * instance that was bound with the annotation.
    */
-  Object getInstanceOf(Type type, {annotatedWith}) {
+  Object getInstanceOf(Type type, {Object annotatedWith}) {
     var key = new Key(_typeName(type), annotatedWith: annotatedWith);
     
     if (_newInstances.contains(key) && !_bindings.containsKey(key)) {
@@ -218,7 +218,9 @@ class Injector {
   List<Object> _resolveParameters(List<ParameterMirror> parameters) =>
       parameters.where((parameter) => !parameter.isOptional).map(
           (parameter) =>
-            _getInstanceOf(new Key(parameter.type.qualifiedName, annotatedWith: getBindingAnnotation(parameter)))
+            _getInstanceOf(
+                new Key(parameter.type.qualifiedName, 
+                    annotatedWith: getBindingAnnotation(parameter)))
       ).toList(growable: false);
 
   void _registerBindings(Type moduleType){
@@ -333,7 +335,7 @@ class Injector {
   /**
    * Create a new constructor binding for [type]
    */
-  Key _createBindingForType(Type type, {annotatedWith}) {
+  Key _createBindingForType(Type type, {Object annotatedWith}) {
     var classMirror = reflectClass(type);
     // Select appropriate constructor
     MethodMirror ctor = _selectConstructor(classMirror);
@@ -431,7 +433,7 @@ abstract class Module {
   Injector _currentInjector;
   Key _currentKey;
 
-  Binder bindTo(Type type, {annotatedWith}) {
+  Binder bindTo(Type type, {Object annotatedWith}) {
     assert(_currentInjector != null);
     assert(_currentKey != null);
     

--- a/lib/dado.dart
+++ b/lib/dado.dart
@@ -228,7 +228,10 @@ class Injector {
       metadata = m.metadata;
     } on NoSuchMethodError catch (e) {
       return null;
+    } on UnimplementedError catch (e) {
+      return null;
     }
+    
     if (metadata.isNotEmpty) {
       // TODO(justin): what do we do when a declaration has multiple
       // annotations? What does Guice do? We should probably only allow one

--- a/lib/dado.dart
+++ b/lib/dado.dart
@@ -65,14 +65,15 @@ import 'src/mirror_utils.dart';
 part 'src/binding.dart';
 
 Symbol _typeName(type) {
-  if (type is Type)
+  if (type is Type) {
     return reflectClass(type).qualifiedName;
-  else if (type is TypeMirror)
+  } else if (type is TypeMirror) {
     return type.qualifiedName;
-  else if (type is Symbol)
+  } else if (type is Symbol) {
     return type;
-  else
+  } else {
     throw new ArgumentError("type must be a Type, a TypeMirror or a Symbol");
+  }
 }
 
 Key _makeKey(dynamic k) => (k is Key) ? k : new Key.forType(k);

--- a/lib/dado.dart
+++ b/lib/dado.dart
@@ -314,7 +314,7 @@ class Injector {
         (m) => m.reflectee == inject)
       , orElse: () => null);
       
-    // In case there is no constructor annotated with @inject, try the single constructor or a no-args one.
+    // In case there is no constructor annotated with @inject, see if there's a single constructor or a no-args.
     if (ctor == null) {
       if (constructors.length == 1) {
         ctor = constructors.first;

--- a/lib/src/binding.dart
+++ b/lib/src/binding.dart
@@ -14,37 +14,38 @@ abstract class Binding {
   final bool singleton;
   Object singletonInstance;
   
-  Binding (Key this.key, InstanceMirror this.moduleMirror, 
+  Binding(Key this.key, InstanceMirror this.moduleMirror, 
       {bool this.singleton: false});
   
-  Object getInstance (Injector injector) {
+  Object getInstance(Injector injector) {
     if (singleton && singletonInstance != null)
       return singletonInstance;
     
     var instance = buildInstance(injector);
     
-    if (singleton)
+    if (singleton) {
       singletonInstance = instance;
+    }
     
     return instance;
   }
   
-  Object buildInstance (Injector injector);
+  Object buildInstance(Injector injector);
   
-  Iterable<Key> getDependencies ();
+  Iterable<Key> getDependencies();
   
 }
 
 class _InstanceBinding extends Binding {
   
-  _InstanceBinding (Key key, Object instance, InstanceMirror moduleMirror) : 
+  _InstanceBinding(Key key, Object instance, InstanceMirror moduleMirror) : 
     super(key, moduleMirror, singleton: true) {
     singletonInstance = instance;
   }
   
-  Object buildInstance (Injector injector) => singletonInstance;
+  Object buildInstance(Injector injector) => singletonInstance;
   
-  Iterable<Key> getDependencies () => [];
+  Iterable<Key> getDependencies() => [];
   
 }
 
@@ -56,28 +57,25 @@ class _ProviderBinding extends Binding {
       {bool singleton: false}) :
         super(key, moduleMirror, singleton: singleton);
   
-  Object buildInstance (Injector injector) {
+  Object buildInstance(Injector injector) {
     if (moduleMirror == null)
       return null;
     
     moduleMirror.reflectee._currentInjector = injector;
     moduleMirror.reflectee._currentKey = key;
     
-    var obj;
     if (!provider.isGetter) {
       var parameters = injector._resolveParameters(provider.parameters);
-      obj = moduleMirror
+      return moduleMirror
           .invoke(provider.simpleName, parameters, null).reflectee;
     } else {
-      obj = moduleMirror.getField(provider.simpleName).reflectee;
+      return moduleMirror.getField(provider.simpleName).reflectee;
     }
-    
-    return obj;
   }
   
-  Iterable<Key> getDependencies () {
+  Iterable<Key> getDependencies() {
     return provider.parameters.map((parameter) {
-      var name = _typeName(parameter.type);
+      var name = parameter.type.qualifiedName;
       var annotation = getBindingAnnotation(parameter);
       return new Key(name, annotatedWith: annotation);
     });
@@ -93,7 +91,7 @@ class _ConstructorBinding extends _ProviderBinding {
       super(key, constructor, moduleMirror, singleton: singleton);
   
   @override
-  Object buildInstance (Injector injector) {
+  Object buildInstance(Injector injector) {
     var parameters = injector._resolveParameters(provider.parameters);
     var obj = (provider.owner as ClassMirror)
         .newInstance(provider.constructorName, parameters, null).reflectee;

--- a/lib/src/binding.dart
+++ b/lib/src/binding.dart
@@ -1,20 +1,24 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 part of dado;
 
 /**
  * Bindings define the way that instances of a [Key] are created. They are used
  * to hide all the logic needed to build an instance, store a singleton instance
- * and analize dependencies.
+ * and analyze dependencies.
  * 
  * This is an interface, so there can be several types of Bindings, each one 
  * with its own internal logic to build instances and define its scope.
  */
-abstract class Binding {
+abstract class _Binding {
   final Key key;
   final InstanceMirror moduleMirror;
   final bool singleton;
   Object singletonInstance;
   
-  Binding(Key this.key, InstanceMirror this.moduleMirror, 
+  _Binding(Key this.key, InstanceMirror this.moduleMirror, 
       {bool this.singleton: false});
   
   Object getInstance(Injector injector) {
@@ -36,7 +40,7 @@ abstract class Binding {
   
 }
 
-class _InstanceBinding extends Binding {
+class _InstanceBinding extends _Binding {
   
   _InstanceBinding(Key key, Object instance, InstanceMirror moduleMirror) : 
     super(key, moduleMirror, singleton: true) {
@@ -49,7 +53,7 @@ class _InstanceBinding extends Binding {
   
 }
 
-class _ProviderBinding extends Binding {
+class _ProviderBinding extends _Binding {
   final MethodMirror provider;
   
   _ProviderBinding 

--- a/lib/src/binding.dart
+++ b/lib/src/binding.dart
@@ -1,16 +1,17 @@
 part of dado;
 
-class BindingType {
-  final String value;
-  
-  const BindingType (this.value);
-}
-
+/**
+ * Bindings define the way that instances of a [Key] are created. They are used
+ * to hide all the logic needed to build an instance, store a singleton instance
+ * and analize dependencies.
+ * 
+ * This is an interface, so there can be several types of Bindings, each one 
+ * with its own internal logic to build instances and define its scope.
+ */
 abstract class Binding {
   final Key key;
-  final BindingType bindingType;
   
-  Binding (this.key, this.bindingType);
+  Binding (this.key);
   
   Object getInstance (Injector injector);
   
@@ -19,11 +20,11 @@ abstract class Binding {
   void _verifyCircularDependency (Injector injector, {List<Key> dependencyStack});
 }
 
-class InstanceBinding extends Binding {
+class _InstanceBinding extends Binding {
   final Object instance;
   
-  InstanceBinding (Key key, Object this.instance) : 
-    super(key, const BindingType('instance'));
+  _InstanceBinding (Key key, Object this.instance) : 
+    super(key);
   
   Object getInstance (Injector injector) => instance;
   
@@ -32,18 +33,18 @@ class InstanceBinding extends Binding {
   void _verifyCircularDependency (Injector injector, {List<Key> dependencyStack}) {}
 }
 
-class ConstructorBinding extends Binding {
+class _ConstructorBinding extends Binding {
   final MethodMirror constructor;
   final bool singleton;
   Object singletonInstance;
   
-  ConstructorBinding 
+  _ConstructorBinding 
     (Key key, MethodMirror this.constructor) :
-    singleton = false, super(key, const BindingType('constructor'));
+    singleton = false, super(key);
   
-  ConstructorBinding.asSingleton
+  _ConstructorBinding.asSingleton
     (Key key, MethodMirror this.constructor) :
-    singleton = true, super(key, const BindingType('singletonConstructor'));
+    singleton = true, super(key);
   
   Object getInstance (Injector injector) {
     if (singleton && singletonInstance != null)
@@ -93,19 +94,19 @@ class ConstructorBinding extends Binding {
   }
 }
 
-class ProviderBinding extends Binding {
+class _ProviderBinding extends Binding {
   final MethodMirror provider;
   final bool singleton;
   final InstanceMirror moduleMirror;
   Object singletonInstance;
   
-  ProviderBinding 
+  _ProviderBinding 
     (Key key, MethodMirror this.provider, InstanceMirror this.moduleMirror) :
-    singleton = false, super(key, const BindingType('provider'));
+    singleton = false, super(key);
   
-  ProviderBinding.asSingleton
+  _ProviderBinding.asSingleton
     (Key key, MethodMirror this.provider, InstanceMirror this.moduleMirror) :
-    singleton = true, super(key, const BindingType('singletonProvider'));
+    singleton = true, super(key);
   
   Object getInstance (Injector injector) {
     if (singleton && singletonInstance != null)

--- a/lib/src/binding.dart
+++ b/lib/src/binding.dart
@@ -1,0 +1,164 @@
+part of dado;
+
+class BindingType {
+  final String value;
+  
+  const BindingType (this.value);
+}
+
+abstract class Binding {
+  final Key key;
+  final BindingType bindingType;
+  
+  Binding (this.key, this.bindingType);
+  
+  Object getInstance (Injector injector);
+  
+  Object getSingleton (Injector injector);
+  
+  void _verifyCircularDependency (Injector injector, {List<Key> dependencyStack});
+}
+
+class InstanceBinding extends Binding {
+  final Object instance;
+  
+  InstanceBinding (Key key, Object this.instance) : 
+    super(key, const BindingType('instance'));
+  
+  Object getInstance (Injector injector) => instance;
+  
+  Object getSingleton (Injector injector) => instance;
+  
+  void _verifyCircularDependency (Injector injector, {List<Key> dependencyStack}) {}
+}
+
+class ConstructorBinding extends Binding {
+  final MethodMirror constructor;
+  final bool singleton;
+  Object singletonInstance;
+  
+  ConstructorBinding 
+    (Key key, MethodMirror this.constructor) :
+    singleton = false, super(key, const BindingType('constructor'));
+  
+  ConstructorBinding.asSingleton
+    (Key key, MethodMirror this.constructor) :
+    singleton = true, super(key, const BindingType('singletonConstructor'));
+  
+  Object getInstance (Injector injector) {
+    if (singleton && singletonInstance != null)
+      return singletonInstance;
+    
+    var parameters = injector._resolveParameters(constructor.parameters);
+    var obj = (constructor.owner as ClassMirror)
+        .newInstance(constructor.constructorName, parameters, null).reflectee;
+    
+    if (singleton)
+      singletonInstance = obj;
+    
+    return obj;
+  }
+  
+  Object getSingleton (Injector injector) {
+    if (singletonInstance == null)
+      singletonInstance = getInstance(injector);
+    
+    return singletonInstance;
+  }
+  
+  void _verifyCircularDependency (Injector injector, {List<Key> dependencyStack}) {
+    if (dependencyStack == null)
+      dependencyStack = [key];
+    
+    var parametersKeys = constructor.parameters.map((p) {
+      var name = _typeName(p.type);
+      var annotation = injector._getAnnotation(p);
+      return new Key(name, annotatedWith: annotation);
+    });
+    
+    parametersKeys.forEach((parameterKey) {
+      if (dependencyStack.contains(parameterKey))
+        throw new ArgumentError(
+            'Circular dependency found on type ${parameterKey.name}');
+      
+      var parameterBinding = injector._getBinding(parameterKey);
+      
+      if (parameterBinding == null)
+        throw new ArgumentError('Key: $parameterKey has not been bound.');
+      
+      dependencyStack.add(parameterKey);
+      parameterBinding._verifyCircularDependency(injector, dependencyStack: dependencyStack);
+      dependencyStack.remove(parameterKey);
+    });
+  }
+}
+
+class ProviderBinding extends Binding {
+  final MethodMirror provider;
+  final bool singleton;
+  final InstanceMirror moduleMirror;
+  Object singletonInstance;
+  
+  ProviderBinding 
+    (Key key, MethodMirror this.provider, InstanceMirror this.moduleMirror) :
+    singleton = false, super(key, const BindingType('provider'));
+  
+  ProviderBinding.asSingleton
+    (Key key, MethodMirror this.provider, InstanceMirror this.moduleMirror) :
+    singleton = true, super(key, const BindingType('singletonProvider'));
+  
+  Object getInstance (Injector injector) {
+    if (singleton && singletonInstance != null)
+      return singletonInstance;
+    
+    moduleMirror.reflectee._currentInjector = injector;
+    moduleMirror.reflectee._currentKey = key;
+    
+    var obj;
+    if (!provider.isGetter) {
+      var parameters = injector._resolveParameters(provider.parameters);
+      obj = moduleMirror
+          .invoke(provider.simpleName, parameters, null).reflectee;
+    } else {
+      obj = moduleMirror.getField(provider.simpleName).reflectee;
+    }
+    
+    if (singleton)
+      singletonInstance = obj;
+    
+    return obj;
+  }
+  
+  Object getSingleton (Injector injector) {
+    if (singletonInstance == null)
+      singletonInstance = getInstance(injector);
+    
+    return singletonInstance;
+  }
+  
+  void _verifyCircularDependency (Injector injector, {List<Key> dependencyStack}) {
+    if (dependencyStack == null)
+      dependencyStack = [key];
+    
+    var parametersKeys = provider.parameters.map((p) {
+      var name = _typeName(p.type);
+      var annotation = injector._getAnnotation(p);
+      return new Key(name, annotatedWith: annotation);
+    });
+    
+    parametersKeys.forEach((parameterKey) {
+      if (dependencyStack.contains(parameterKey))
+        throw new ArgumentError(
+            'Circular dependency found on type ${parameterKey.name}');
+      
+      var parameterBinding = injector._getBinding(parameterKey);
+      
+      if (parameterBinding == null)
+        throw new ArgumentError('Key: $parameterKey has not been bound.');
+      
+      dependencyStack.add(parameterKey);
+      parameterBinding._verifyCircularDependency(injector, dependencyStack: dependencyStack);
+      dependencyStack.remove(parameterKey);
+    });
+  }
+}

--- a/lib/src/binding.dart
+++ b/lib/src/binding.dart
@@ -16,23 +16,12 @@ abstract class _Binding {
   final Key key;
   final InstanceMirror moduleMirror;
   final bool singleton;
-  Object singletonInstance;
   
   _Binding(Key this.key, InstanceMirror this.moduleMirror, 
       {bool this.singleton: false});
   
-  Object getInstance(Injector injector) {
-    if (singleton && singletonInstance != null)
-      return singletonInstance;
-    
-    var instance = buildInstance(injector);
-    
-    if (singleton) {
-      singletonInstance = instance;
-    }
-    
-    return instance;
-  }
+  Object getInstance(Injector injector) => 
+      buildInstance(injector);
   
   Object buildInstance(Injector injector);
   
@@ -41,13 +30,14 @@ abstract class _Binding {
 }
 
 class _InstanceBinding extends _Binding {
+  Object _instance;
   
   _InstanceBinding(Key key, Object instance, InstanceMirror moduleMirror) : 
     super(key, moduleMirror, singleton: true) {
-    singletonInstance = instance;
+    _instance = instance;
   }
   
-  Object buildInstance(Injector injector) => singletonInstance;
+  Object buildInstance(Injector injector) => _instance;
   
   Iterable<Key> getDependencies() => [];
   

--- a/lib/src/mirror_utils.dart
+++ b/lib/src/mirror_utils.dart
@@ -69,3 +69,24 @@ bool hasSuperclass(ClassMirror classMirror) {
   return (superclass != null)
       && (superclass.qualifiedName != "dart.core.Object");
 }
+
+Object getBindingAnnotation (DeclarationMirror declarationMirror) {
+// There's some bug with requesting metadata from certain variable mirrors
+  // that causes a UnimplementedError. See dartbug.com/11418
+  List<InstanceMirror> metadata;
+  try {
+    metadata = declarationMirror.metadata;
+  } on UnimplementedError catch (e) {
+    return null;
+  }
+  
+  if (metadata.isNotEmpty) {
+    // TODO(justin): what do we do when a declaration has multiple
+    // annotations? What does Guice do? We should probably only allow one
+    // binding annotation per declaration, which means we need a way to
+    // identify binding annotations.
+    return metadata.first.reflectee;
+  }
+  
+  return null;
+}

--- a/lib/src/mirror_utils.dart
+++ b/lib/src/mirror_utils.dart
@@ -69,23 +69,3 @@ bool hasSuperclass(ClassMirror classMirror) {
   return (superclass != null)
       && (superclass.qualifiedName != "dart.core.Object");
 }
-
-Object getBindingAnnotation (DeclarationMirror m) {
-  // There's some bug with requesting metadata from certain variable mirrors
-  // that causes a NoSuchMe thodError because the mirror system is trying to
-  // call 'resolve' on null. See dartbug.com/11418
-  List<InstanceMirror> metadata;
-  try {
-    metadata = m.metadata;
-  } on NoSuchMethodError catch (e) {
-    return null;
-  }
-  if (metadata.isNotEmpty) {
-    // TODO(justin): what do we do when a declaration has multiple
-    // annotations? What does Guice do? We should probably only allow one
-    // binding annotation per declaration, which means we need a way to
-    // identify binding annotations.
-    return metadata.first.reflectee;
-  }
-  return null;
-}

--- a/lib/src/mirror_utils.dart
+++ b/lib/src/mirror_utils.dart
@@ -42,10 +42,10 @@ bool implements(ClassMirror m, Symbol name, {bool useSimple: false}) {
 DeclarationMirror getMemberMirror(ClassMirror classMirror, Symbol name) {
   assert(classMirror != null);
   assert(name != null);
-  if (classMirror.members[name] != null) {
-    return classMirror.members[name];
+  if (classMirror.instanceMembers[name] != null) {
+    return classMirror.instanceMembers[name];
   }
-  if (hasSuperclass(classMirror)) {
+  if (classMirror.superclass != null) {
     var memberMirror = getMemberMirror(classMirror.superclass, name);
     if (memberMirror != null) {
       return memberMirror;
@@ -60,18 +60,7 @@ DeclarationMirror getMemberMirror(ClassMirror classMirror, Symbol name) {
   return null;
 }
 
-/**
- * Work-around for http://dartbug.com/5794
- */
-bool hasSuperclass(ClassMirror classMirror) {
-  ClassMirror superclass = classMirror.superclass;
-  return (superclass != null)
-      && (superclass.qualifiedName != "dart.core.Object");
-}
-
 Object getBindingAnnotation (DeclarationMirror declarationMirror) {
-// There's some bug with requesting metadata from certain variable mirrors
-  // that causes a UnimplementedError. See dartbug.com/11418
   List<InstanceMirror> metadata;
   metadata = declarationMirror.metadata;
   
@@ -84,4 +73,15 @@ Object getBindingAnnotation (DeclarationMirror declarationMirror) {
   }
   
   return null;
+}
+
+List<MethodMirror> getConstructorsMirrors(ClassMirror classMirror) {
+  var constructors = new List<MethodMirror>();
+  
+  classMirror.declarations.values.forEach((declaration) {
+    if ((declaration is MethodMirror) && (declaration.isConstructor))
+        constructors.add(declaration);
+  });
+  
+  return constructors;
 }

--- a/lib/src/mirror_utils.dart
+++ b/lib/src/mirror_utils.dart
@@ -69,3 +69,23 @@ bool hasSuperclass(ClassMirror classMirror) {
   return (superclass != null)
       && (superclass.qualifiedName != "dart.core.Object");
 }
+
+Object getBindingAnnotation (DeclarationMirror m) {
+  // There's some bug with requesting metadata from certain variable mirrors
+  // that causes a NoSuchMe thodError because the mirror system is trying to
+  // call 'resolve' on null. See dartbug.com/11418
+  List<InstanceMirror> metadata;
+  try {
+    metadata = m.metadata;
+  } on NoSuchMethodError catch (e) {
+    return null;
+  }
+  if (metadata.isNotEmpty) {
+    // TODO(justin): what do we do when a declaration has multiple
+    // annotations? What does Guice do? We should probably only allow one
+    // binding annotation per declaration, which means we need a way to
+    // identify binding annotations.
+    return metadata.first.reflectee;
+  }
+  return null;
+}

--- a/lib/src/mirror_utils.dart
+++ b/lib/src/mirror_utils.dart
@@ -4,7 +4,6 @@
 
 library dado.mirror_utils;
 
-import 'dart:async';
 import 'dart:collection';
 import 'dart:mirrors';
 
@@ -74,11 +73,7 @@ Object getBindingAnnotation (DeclarationMirror declarationMirror) {
 // There's some bug with requesting metadata from certain variable mirrors
   // that causes a UnimplementedError. See dartbug.com/11418
   List<InstanceMirror> metadata;
-  try {
-    metadata = declarationMirror.metadata;
-  } on UnimplementedError catch (e) {
-    return null;
-  }
+  metadata = declarationMirror.metadata;
   
   if (metadata.isNotEmpty) {
     // TODO(justin): what do we do when a declaration has multiple

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,5 @@ documentation: http://dart-lang.github.io/dado/docs/dado.html
 dependencies:
   inject: any
   logging: any
-  meta: any
 dev_dependencies:
   unittest: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,5 +7,6 @@ documentation: http://dart-lang.github.io/dado/docs/dado.html
 dependencies:
   inject: any
   logging: any
+  meta: any
 dev_dependencies:
   unittest: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ description: An experimental dependency injection container for Dart
 homepage: http://dart-lang.github.io/dado/
 documentation: http://dart-lang.github.io/dado/docs/dado.html
 dependencies:
+  inject: any
   logging: any
 dev_dependencies:
   unittest: any

--- a/test/dado_test.dart
+++ b/test/dado_test.dart
@@ -115,7 +115,7 @@ abstract class Module1 extends Module {
   Bar newBar();
 
   // to test that direct cyclical dependencies fail. TODO: indirect cycles
-  Cycle get newCycle => bindTo(Cycle).newInstance();
+  Cycle newCycle();
   
 //  IndirectCycle newIndirectCycle();
 //  
@@ -151,8 +151,6 @@ abstract class Module3 extends Module {
 }
 
 main() {
-  new Injector([Module3]);
-  new Injector([Module1]);
 
   group('injector',(){
     Injector injector;

--- a/test/dado_test.dart
+++ b/test/dado_test.dart
@@ -64,6 +64,23 @@ class Provided {
   Provided(int this.i, Foo foo);
 }
 
+class HasAnnotatedConstructor {
+  String a;
+  
+  HasAnnotatedConstructor ();
+  
+  @inject
+  HasAnnotatedConstructor.second (String this.a);
+}
+
+class HasNoArgsConstructor {
+  String a;
+  
+  HasNoArgsConstructor (String this.a);
+  
+  HasNoArgsConstructor.noArgs ();
+}
+
 const A = 'a';
 const B = 'b';
 
@@ -90,6 +107,10 @@ abstract class Module1 extends Module {
 
   // a class that injects the module
   NeedsInjector needsInjector();
+  
+  HasAnnotatedConstructor hasAnnotatedConstructor(); 
+  
+  HasNoArgsConstructor hasNoArgsConstructor(); 
 
   Baz get baz => bindTo(SubBaz).singleton;
 
@@ -191,6 +212,19 @@ main() {
         called = true;
       });
       expect(called, true);
+    });
+    
+
+    test('should use annotated constructor', () {
+      var o = injector.getInstanceOf(HasAnnotatedConstructor);
+      expect(o, new isInstanceOf<HasAnnotatedConstructor>());
+      expect(o.a, 'a');
+    });
+    
+    test('should use no-args  constructor', () {
+      var o = injector.getInstanceOf(HasNoArgsConstructor);
+      expect(o, new isInstanceOf<HasNoArgsConstructor>());
+      expect(o.a, null);
     });
 
   });

--- a/test/dado_test.dart
+++ b/test/dado_test.dart
@@ -12,10 +12,6 @@ import 'package:unittest/unittest.dart';
 class Foo {
   String name;
   
-  @inject
-  NeedsInjector b;
-  
-  @inject
   Foo(String this.name);
   
   String toString() => "Foo { name: $name}";
@@ -25,7 +21,6 @@ class Foo {
 class Bar {
   Foo foo;
   
-  @inject
   Bar(Foo this.foo);
   
   String toString() => "Bar {foo: $foo}";
@@ -33,7 +28,6 @@ class Bar {
 
 // subclass of dependency for binding
 class SubBar extends Bar {
-  @inject
   SubBar(Foo foo) : super(foo);
 }
 
@@ -41,12 +35,10 @@ class SubBar extends Bar {
 class Baz {
   Bar bar;
 
-  @inject
   Baz(Bar this.bar);
 }
 
 class SubBaz extends Baz {
-  @inject
   SubBaz(Bar bar) : super(bar);
 }
 
@@ -55,7 +47,6 @@ class Qux {
 
 // object with a cyclic, unscoped dependency
 class Cycle {
-  @inject
   Cycle(Cycle c);
 }
 
@@ -63,7 +54,6 @@ class Cycle {
 class NeedsInjector {
   Injector injector;
   
-  @inject
   NeedsInjector(Injector this.injector);
 }
 

--- a/test/dado_test.dart
+++ b/test/dado_test.dart
@@ -114,9 +114,9 @@ abstract class Module1 extends Module {
   // a factory binding, similar to bind().to() in Guice
   Bar newBar();
 
-  // to test that direct cyclical dependencies fail. TODO: indirect cycles
-  Cycle newCycle();
-  
+  // to test that direct cyclical dependencies fail.
+//  Cycle newCycle();
+//  
 //  IndirectCycle newIndirectCycle();
 //  
 //  IndirectCycle2 newIndirectCycle2();
@@ -151,6 +151,8 @@ abstract class Module3 extends Module {
 }
 
 main() {
+  new Injector([Module3]);
+  new Injector([Module1]);
 
   group('injector',(){
     Injector injector;

--- a/test/dado_test.dart
+++ b/test/dado_test.dart
@@ -166,6 +166,7 @@ abstract class Module5 extends Module {
 }
 
 main() {
+  new Injector([Module5]);
   group('injector',(){
     Injector injector;
 

--- a/test/dado_test.dart
+++ b/test/dado_test.dart
@@ -114,13 +114,6 @@ abstract class Module1 extends Module {
   // a factory binding, similar to bind().to() in Guice
   Bar newBar();
 
-  // to test that direct cyclical dependencies fail.
-//  Cycle newCycle();
-//  
-//  IndirectCycle newIndirectCycle();
-//  
-//  IndirectCycle2 newIndirectCycle2();
-
   // a class that injects the module
   NeedsInjector needsInjector();
   
@@ -150,10 +143,19 @@ abstract class Module3 extends Module {
   Bar newBar() => bindTo(SubBar).newInstance();
 }
 
-main() {
-  new Injector([Module3]);
-  new Injector([Module1]);
+abstract class Module4 extends Module {
+  // to test that direct cyclical dependencies fail.
+  Cycle newCycle();
+}
 
+abstract class Module5 extends Module {
+  // to test that indirect cyclical dependencies fail.
+  IndirectCycle newIndirectCycle();
+  
+  IndirectCycle2 newIndirectCycle2();
+}
+
+main() {
   group('injector',(){
     Injector injector;
 
@@ -214,10 +216,6 @@ main() {
       expect(provided.i, 2);
     });
 
-    test('should throw exceptions on dependency cycles', () {
-      expect(() => injector.getInstanceOf(Cycle), throws);
-    });
-
     test('should inject itself', () {
       NeedsInjector o = injector.getInstanceOf(NeedsInjector);
       expect(o.injector, same(injector));
@@ -232,17 +230,24 @@ main() {
       expect(called, true);
     });
     
-
     test('should use annotated constructor', () {
       var o = injector.getInstanceOf(HasAnnotatedConstructor);
       expect(o, new isInstanceOf<HasAnnotatedConstructor>());
       expect(o.a, 'a');
     });
     
-    test('should use no-args  constructor', () {
+    test('should use no-args constructor', () {
       var o = injector.getInstanceOf(HasNoArgsConstructor);
       expect(o, new isInstanceOf<HasNoArgsConstructor>());
       expect(o.a, null);
+    });
+    
+    test('should throw ArgumentError on direct cyclical dependencies', () {
+      expect(() => new Injector([Module4]), throwsArgumentError);
+    });
+    
+    test('should throw ArgumentError on indirect cyclical dependencies', () {
+      expect(() => new Injector([Module5]), throwsArgumentError);
     });
 
   });
@@ -318,5 +323,5 @@ main() {
     });
 
   });
-
+  
 }

--- a/test/dado_test.dart
+++ b/test/dado_test.dart
@@ -166,7 +166,6 @@ abstract class Module5 extends Module {
 }
 
 main() {
-  new Injector([Module5]);
   group('injector',(){
     Injector injector;
 

--- a/test/dado_test.dart
+++ b/test/dado_test.dart
@@ -81,6 +81,18 @@ class HasNoArgsConstructor {
   HasNoArgsConstructor.noArgs ();
 }
 
+class IndirectCycle {
+  IndirectCycle2 id;
+  
+  IndirectCycle (IndirectCycle2 this.id);
+}
+
+class IndirectCycle2 {
+  IndirectCycle id;
+  
+  IndirectCycle2 (IndirectCycle this.id);
+}
+
 const A = 'a';
 const B = 'b';
 
@@ -103,7 +115,11 @@ abstract class Module1 extends Module {
   Bar newBar();
 
   // to test that direct cyclical dependencies fail. TODO: indirect cycles
-  Cycle newCycle();
+  Cycle get newCycle => bindTo(Cycle).newInstance();
+  
+//  IndirectCycle newIndirectCycle();
+//  
+//  IndirectCycle2 newIndirectCycle2();
 
   // a class that injects the module
   NeedsInjector needsInjector();
@@ -135,6 +151,8 @@ abstract class Module3 extends Module {
 }
 
 main() {
+  new Injector([Module3]);
+  new Injector([Module1]);
 
   group('injector',(){
     Injector injector;

--- a/test/dado_test.dart
+++ b/test/dado_test.dart
@@ -67,18 +67,18 @@ class Provided {
 class HasAnnotatedConstructor {
   String a;
   
-  HasAnnotatedConstructor ();
+  HasAnnotatedConstructor();
   
   @inject
-  HasAnnotatedConstructor.second (String this.a);
+  HasAnnotatedConstructor.second(String this.a);
 }
 
 class HasNoArgsConstructor {
   String a;
   
-  HasNoArgsConstructor (String this.a);
+  HasNoArgsConstructor(String this.a);
   
-  HasNoArgsConstructor.noArgs ();
+  HasNoArgsConstructor.noArgs();
 }
 
 
@@ -86,19 +86,19 @@ class HasNoArgsConstructor {
 class Quux {
   Corge corge;
   
-  Quux (Corge this.corge);
+  Quux(Corge this.corge);
 }
 
 class Corge {
   Grault grault;
   
-  Corge (Grault this.grault);
+  Corge(Grault this.grault);
 }
 
 class Grault {
   Quux quux;
   
-  Grault (Quux this.quux);
+  Grault(Quux this.quux);
 }
 
 const A = 'a';

--- a/test/dado_test.dart
+++ b/test/dado_test.dart
@@ -81,16 +81,24 @@ class HasNoArgsConstructor {
   HasNoArgsConstructor.noArgs ();
 }
 
-class IndirectCycle {
-  IndirectCycle2 id;
+
+// Indirect circular dependency tests classes
+class Quux {
+  Corge corge;
   
-  IndirectCycle (IndirectCycle2 this.id);
+  Quux (Corge this.corge);
 }
 
-class IndirectCycle2 {
-  IndirectCycle id;
+class Corge {
+  Grault grault;
   
-  IndirectCycle2 (IndirectCycle this.id);
+  Corge (Grault this.grault);
+}
+
+class Grault {
+  Quux quux;
+  
+  Grault (Quux this.quux);
 }
 
 const A = 'a';
@@ -150,9 +158,11 @@ abstract class Module4 extends Module {
 
 abstract class Module5 extends Module {
   // to test that indirect cyclical dependencies fail.
-  IndirectCycle newIndirectCycle();
+  Quux newQuux();
   
-  IndirectCycle2 newIndirectCycle2();
+  Corge newCorge();
+  
+  Grault newGrault();
 }
 
 main() {

--- a/test/dado_test.dart
+++ b/test/dado_test.dart
@@ -4,35 +4,49 @@
 
 library dado_test;
 
-import 'package:unittest/unittest.dart';
 import 'package:dado/dado.dart';
+import 'package:inject/inject.dart';
+import 'package:unittest/unittest.dart';
 
 // object with a dependency bound to an instance
 class Foo {
   String name;
+  
+  @inject
+  NeedsInjector b;
+  
+  @inject
   Foo(String this.name);
+  
   String toString() => "Foo { name: $name}";
 }
 
 // object with a singleton dependecy
 class Bar {
   Foo foo;
+  
+  @inject
   Bar(Foo this.foo);
+  
   String toString() => "Bar {foo: $foo}";
 }
 
 // subclass of dependency for binding
 class SubBar extends Bar {
+  @inject
   SubBar(Foo foo) : super(foo);
 }
 
 // object with an unscoped (non-singleton) dependency
 class Baz {
   Bar bar;
+
+  @inject
   Baz(Bar this.bar);
 }
 
 class SubBaz extends Baz {
+  @inject
   SubBaz(Bar bar) : super(bar);
 }
 
@@ -41,18 +55,22 @@ class Qux {
 
 // object with a cyclic, unscoped dependency
 class Cycle {
+  @inject
   Cycle(Cycle c);
 }
 
 // object that depends on the module
 class NeedsInjector {
   Injector injector;
+  
+  @inject
   NeedsInjector(Injector this.injector);
 }
 
 // a class that's not injectable, and so needs a provider function
 class Provided {
   final int i;
+  
   Provided(int this.i, Foo foo);
 }
 
@@ -60,6 +78,7 @@ const A = 'a';
 const B = 'b';
 
 abstract class Module1 extends Module {
+  int number = 1;
 
   // an instance of a type, similar to bind().toInstance() in Guice
   String string = "a";


### PR DESCRIPTION
## Constructor selection based on @inject

The constructor is selected following this rules:

1- Is there any constructor annotated with @inject?
2- Is there only one constructor?
3- Is there a no-args constructor?

The first rule to pass is used to define the constructor. In case none of this rules pass, an exception is raised.
## Reformulated binding registration

Instead of creating provider functions for everything and having a map for singletons, now there is an actual Binding abstract class that defines a interface so that the instance construction and scope management logic can be abstracted from the Injector.
The main benefits of this new binding registration on this pull request is that constructors only have to be selected once for each binding (_ConstructorBinding stores the selected constructor so it can always use it without having to search for it again) and provider bindings can be verified for circular dependencies (_ProviderBinding stores the MethodMirror so it can know its parameters).
##  Circular dependency verification

After all the bindings were registered, they are analyzed to see if there is any circular dependency. This verification DOES NOT work in cases where the injector itself is injected (this includes bindTo cases, as the injector is injected silently into the module, as the constructor or provider can try to inject itself using it and there is no way to see this on the injectors initialization.
